### PR TITLE
Fix previous update and add Transfer name for material name

### DIFF
--- a/nothing-is-3d/meshes.py
+++ b/nothing-is-3d/meshes.py
@@ -18,7 +18,7 @@ def meshes_names_to_clipboard():
         if obj is objects_selected[-1]:
             meshes_names_to_clipboard += '"{}"'.format(obj.name)
         else:
-            meshes_names_to_clipboard += '"{},"'.format(obj.name)
+            meshes_names_to_clipboard += '"{}",'.format(obj.name)
     bpy.context.window_manager.clipboard = meshes_names_to_clipboard
     return {'FINISHED'}
 


### PR DESCRIPTION
Fix on the previous update to move quotation marks
and
Add "Transfer names" to copy Object Names to its material name (Slot 0)